### PR TITLE
Publish only binaries, protobuf model and license

### DIFF
--- a/.github/actions/set-environment-variables/action.yaml
+++ b/.github/actions/set-environment-variables/action.yaml
@@ -22,6 +22,8 @@ runs:
         
         printf "RELEASE_PATH=%s\n" "${{ github.workspace }}/build/Release" >> $GITHUB_ENV
         
+        printf "ARTIFACT_PATH=%s\n" "${{ github.workspace }}/artifact" >> $GITHUB_ENV
+        
         repositoryName="$(printf "%s" "${{ github.repository }}" | sed -e "s/^${{ github.repository_owner }}\///")"
         lowercaseRepositoryName="${repositoryName,,}"
         printf "LOWERCASE_REPOSITORY_NAME=%s\n" "${lowercaseRepositoryName}" >> $GITHUB_ENV

--- a/.github/workflows/build-test-and-publish-release.yaml
+++ b/.github/workflows/build-test-and-publish-release.yaml
@@ -35,12 +35,24 @@ jobs:
       - name: Test
         uses: ./.github/actions/test
 
-      - name: Move license to release directory
-        run: mv ${{ github.workspace }}/LICENSE ${{ env.RELEASE_PATH }}/LICENSE
+      - name: Create artifact directory
+        run: mkdir ${{ env.ARTIFACT_PATH }}
 
-      - name: Zip release directory contents
+      - name: Move license to artifact directory
+        run: mv ${{ github.workspace }}/LICENSE ${{ env.ARTIFACT_PATH }}/LICENSE
+
+      - name: Move protobuf model to artifact directory
+        run: mv ${{ env.RELEASE_PATH }}/libebpfdiscoveryproto/proto/ebpfdiscoveryproto ${{ env.ARTIFACT_PATH }}/ebpfdiscoveryproto
+
+      - name: Move binaries to artifact directory
+        run: mv ${{ env.RELEASE_PATH }}/bin ${{ env.ARTIFACT_PATH }}/bin
+
+      - name: Remove test binaries from artifact directory
+        run: find ${{ env.ARTIFACT_PATH }}/* -name 'test*' -exec rm {} \;
+
+      - name: Zip artifact directory contents
         run: |
-          cd ${{ env.RELEASE_PATH }}
+          cd ${{ env.ARTIFACT_PATH }}
           zip -r ${{ env.GITHUB_OCI_REGISTRY_ARTIFACT_VERSION }}.zip .
 
       - name: Login to GitHub OCI registry
@@ -48,5 +60,5 @@ jobs:
 
       - name: Publish zip to GitHub OCI registry
         run: |
-          cd ${{ env.RELEASE_PATH }}
+          cd ${{ env.ARTIFACT_PATH }}
           oras push ${{ env.GITHUB_OCI_REGISTRY_ADDRESS }}:${{ env.GITHUB_OCI_REGISTRY_ARTIFACT_VERSION }} ${{ env.GITHUB_OCI_REGISTRY_ARTIFACT_VERSION }}.zip


### PR DESCRIPTION
Previously, a whole Release directory along with a license were published.
![image](https://github.com/dynatrace-oss/eBPF-Discovery/assets/68189467/926da987-e58e-40b4-b78f-a89457acb52c)
![image](https://github.com/dynatrace-oss/eBPF-Discovery/assets/68189467/21816699-d880-473c-8cb0-4c003b3331a7)
![image](https://github.com/dynatrace-oss/eBPF-Discovery/assets/68189467/aea8bca9-ab43-4aa3-9ed1-4acaed388e27)

