### PR TITLE
Change Oras version to compatible with Python SDK

### DIFF
--- a/.github/workflows/build-test-and-publish-release.yaml
+++ b/.github/workflows/build-test-and-publish-release.yaml
@@ -54,11 +54,7 @@ jobs:
           cd ${{ env.ARTIFACT_PATH }}
           zip -r ${{ env.ARTIFACT_VERSION }}.zip .
 
-      - name: Login to GitHub OCI registry
-        run: printf "%s" ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-
       - name: Publish zip to GitHub OCI registry
         run: |
           cd ${{ env.ARTIFACT_PATH }}
-          oras push ${{ env.GITHUB_OCI_REGISTRY_ADDRESS }}/${{ env.LOWERCASE_REPOSITORY_NAME }}-linux-x86_64:${{ env.ARTIFACT_VERSION }} ${{ env.ARTIFACT_VERSION }}.zip
-          oras push ${{ env.GITHUB_OCI_REGISTRY_ADDRESS }}/${{ env.LOWERCASE_REPOSITORY_NAME }}-linux-x86_64:latest ${{ env.ARTIFACT_VERSION }}.zip
+          printf "%s" ${{ secrets.GITHUB_TOKEN }} | docker run --rm -i -v $(pwd):/workspace ghcr.io/oras-project/oras:v1.0.1 push -u ${{ github.actor }} --password-stdin ${{ env.GITHUB_OCI_REGISTRY_ADDRESS }}/${{ env.LOWERCASE_REPOSITORY_NAME }}-linux-x86_64:${{ env.ARTIFACT_VERSION }},latest ${{ env.ARTIFACT_VERSION }}.zip


### PR DESCRIPTION
We need to use older Oras version due to incompatibility of Oras 1.1.0 with the latest Oras Python SDK 