### PR TITLE
Switch to static linking for liblogging

### DIFF
--- a/liblogging/CMakeLists.txt
+++ b/liblogging/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND SOURCES src/Logger.cpp)
 set(TARGET logging)
 
-add_library(${TARGET} SHARED ${SOURCES})
+add_library(${TARGET} STATIC ${SOURCES})
 target_include_directories(${TARGET} PRIVATE src PUBLIC headers)
 target_link_libraries(${TARGET} spdlog::spdlog)


### PR DESCRIPTION
We need to have a single deployable binary. That's not possible with the current dynamic linking of liblogging.