### PR TITLE
Add thirdparty licenses to published image

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,5 +11,3 @@ CMakeDeps
 CMakeToolchain
 [layout]
 cmake_layout
-[imports]
-., license* -> ./licenses @ folder=True, ignore_case=True


### PR DESCRIPTION
## A few notices:
* `protobuf` and `protobuf-c` licenses have not been saved in conan cache (why?)
* I have decided to download both of these licenses directly from their respective repositories
* example artifact can be found below
[0.0.0-20231023_120838.zip](https://github.com/dynatrace-oss/eBPF-Discovery/files/13069903/0.0.0-20231023_120838.zip)
* please, check if its structure looks appropriate
