### PR TITLE
feat: Basic handling of X-Forwarded-For with IPv4

### DIFF
--- a/libebpfdiscovery/src/Discovery.cpp
+++ b/libebpfdiscovery/src/Discovery.cpp
@@ -147,31 +147,32 @@ void Discovery::handleNewSession(std::string_view& bufferView, DiscoveryEvent& e
 
 void Discovery::handleNewRequest(const Session& session, const DiscoverySessionMeta& meta) {
 	const auto& request{session.parser.result};
+	const auto xForwardedForClient{request.xForwardedFor.empty() ? "" : ", X-Forwarded-For client: " + request.xForwardedFor.front()};
 	if (discoverySessionFlagsIsIPv4(meta.flags)) {
 		LOG_DEBUG(
-				"Handling new request. (method:'{}', host:'{}', url:'{}', X-Forwarded-For:'{}', sourceIPv4:'{}', pid:{})",
+				"Handling new request. (method: {}, host: {}, url: {}{}, sourceIPv4: '{}', pid: {})",
 				request.method,
 				request.host,
 				request.url,
-				request.xForwardedFor,
+				xForwardedForClient,
 				ipv4ToString(meta.sourceIPData),
 				meta.pid);
 	} else if (discoverySessionFlagsIsIPv6(meta.flags)) {
 		LOG_DEBUG(
-				"Handling new request. (method:'{}', host:'{}', url:'{}', X-Forwarded-For:'{}', sourceIPv6:'{}', pid:{})",
+				"Handling new request. (method: {}, host: {}, url: {}{}, sourceIPv6: {}, pid: {})",
 				request.method,
 				request.host,
 				request.url,
-				request.xForwardedFor,
+				xForwardedForClient,
 				ipv6ToString(meta.sourceIPData),
 				meta.pid);
 	} else {
 		LOG_DEBUG(
-				"Handling new request. (method:'{}', host:'{}', url:'{}', X-Forwarded-For:'{}', pid:{})",
+				"Handling new request. (method: {}, host: {}, url: {}{}, pid: {})",
 				request.method,
 				request.host,
 				request.url,
-				request.xForwardedFor,
+				xForwardedForClient,
 				meta.pid);
 	}
 	serviceAggregator.newRequest(request, meta);

--- a/libhttpparser/headers/httpparser/HttpRequestParser.h
+++ b/libhttpparser/headers/httpparser/HttpRequestParser.h
@@ -9,23 +9,12 @@
 
 namespace httpparser {
 
-struct XForwardedFor {
-	std::vector<std::string> addresses;
-	void clear();
-};
-
-class XForwardedForValueParser {
-public:
-	void parse(std::string_view data);
-	XForwardedFor result;
-};
-
 struct HttpRequest {
 	std::string method;
 	std::string url;
 	std::string protocol;
 	std::string host;
-	std::string xForwardedFor;
+	std::vector<std::string> xForwardedFor;
 
 	HttpRequest();
 	void clear();
@@ -81,7 +70,14 @@ private:
 	bool isCurrentHeaderKeyHost();
 	bool isCurrentHeaderKeyXForwardedFor();
 
-	std::string currentHeaderKey;
+	void parseXForwardedFor(const std::string& data);
+
+	struct HttpHeader {
+		std::string key;
+		std::string value;
+	};
+
+	HttpHeader currentHeader;
 	size_t length;
 };
 

--- a/libhttpparser/src/HttpRequestParser.cpp
+++ b/libhttpparser/src/HttpRequestParser.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "httpparser/HttpRequestParser.h"
-#include <iostream>
+
+#include <boost/algorithm/string.hpp>
+
+#include <optional>
 
 namespace httpparser {
 
@@ -45,24 +48,6 @@ inline static bool isValidHostHeaderValueChar(const char ch) {
 
 inline static bool isValidXForwardedForHeaderValueChar(const char ch) {
 	return std::isalnum(ch) || constants::VALID_X_FORWARDED_FOR_HEADER_VALUE_SPECIAL_CHARS.find(ch) != std::string_view::npos;
-}
-
-void XForwardedFor::clear() {
-	addresses.clear();
-}
-
-void XForwardedForValueParser::parse(std::string_view data) {
-	auto beg{0};
-	while (beg < data.length()) {
-		auto end{data.find_first_of(',', beg)};
-		auto const field{data.substr(beg, end - beg)};
-		result.addresses.push_back(std::string(field));
-		if (end == std::string_view::npos) {
-			return;
-		}
-		beg = end + 1;
-	}
-	return;
 }
 
 HttpRequest::HttpRequest() {
@@ -249,7 +234,12 @@ void HttpRequestParser::handleCharHeaderNewline(const char ch) {
 		return;
 	}
 
-	currentHeaderKey.clear();
+	if (isCurrentHeaderKeyXForwardedFor()) {
+		parseXForwardedFor(currentHeader.value);
+	}
+
+	currentHeader = {};
+
 	state = State::HEADER_KEY;
 }
 
@@ -269,8 +259,8 @@ void HttpRequestParser::handleCharHeaderKey(const char ch) {
 			return;
 		}
 
-		if (currentHeaderKey.size() < constants::X_FORWARDED_FOR.size()) {
-			currentHeaderKey.push_back(std::tolower(ch));
+		if (currentHeader.key.size() < constants::X_FORWARDED_FOR.size()) {
+			currentHeader.key.push_back(std::tolower(ch));
 		}
 
 		return;
@@ -281,8 +271,8 @@ void HttpRequestParser::handleCharHeaderKey(const char ch) {
 		return;
 	}
 
-	if (isCurrentHeaderKeyXForwardedFor() && !result.xForwardedFor.empty()) {
-		result.xForwardedFor.push_back(',');
+	if (isCurrentHeaderKeyXForwardedFor() && !currentHeader.value.empty()) {
+		currentHeader.value.push_back(',');
 	}
 
 	state = State::SPACE_BEFORE_HEADER_VALUE;
@@ -301,7 +291,7 @@ void HttpRequestParser::handleCharSpaceBeforeHeaderValue(const char ch) {
 	if (isCurrentHeaderKeyHost()) {
 		result.host.push_back(ch);
 	} else if (isCurrentHeaderKeyXForwardedFor()) {
-		result.xForwardedFor.push_back(ch);
+		currentHeader.value.push_back(ch);
 	}
 
 	state = State::HEADER_VALUE;
@@ -324,7 +314,7 @@ void HttpRequestParser::handleCharHeaderValue(const char ch) {
 			return;
 		}
 
-		result.xForwardedFor.push_back(ch);
+		currentHeader.value.push_back(ch);
 		return;
 	}
 
@@ -353,18 +343,43 @@ void HttpRequestParser::handleCharHeadersEnd(const char ch) {
 }
 
 inline bool HttpRequestParser::isCurrentHeaderKeyHost() {
-	return currentHeaderKey == constants::HOST_LOWER;
+	return currentHeader.key == constants::HOST_LOWER;
 }
 
 inline bool HttpRequestParser::isCurrentHeaderKeyXForwardedFor() {
-	return currentHeaderKey == constants::X_FORWARDED_FOR_LOWER;
+	return currentHeader.key == constants::X_FORWARDED_FOR_LOWER;
 }
 
 void HttpRequestParser::reset() {
 	state = State::METHOD;
-	currentHeaderKey.clear();
+	currentHeader = {};
 	length = 0;
 	result.clear();
+}
+
+static std::optional<std::string> getTextBetweenSquareBrackets(const std::string& input) {
+	if (const auto startPos{input.find('[')}; startPos != std::string::npos) {
+		if (const auto endPos{input.find(']', startPos)}; endPos != std::string::npos) {
+			return input.substr(startPos + 1, endPos - startPos - 1);
+		}
+	}
+	return std::nullopt;
+}
+
+void HttpRequestParser::parseXForwardedFor(const std::string& data) {
+	std::vector<std::string> addresses;
+	boost::split(addresses, data, boost::is_any_of(","), boost::token_compress_on);
+	for (auto& address : addresses) {
+		if (const auto ipv6Address{getTextBetweenSquareBrackets(address)}; ipv6Address) {
+			address = *ipv6Address;
+		} else if (const auto semicolonPos{address.find(':')}; semicolonPos != std::string::npos) {
+			address = address.substr(0, semicolonPos);
+		}
+
+		boost::trim(address);
+	}
+
+	std::copy(addresses.begin(), addresses.end(), std::back_inserter(result.xForwardedFor));
 }
 
 } // namespace httpparser

--- a/libhttpparser/src/XForwardedForValueParser.cpp
+++ b/libhttpparser/src/XForwardedForValueParser.cpp
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-#include "httpparser/XForwardedForValueParser.h"
-
-namespace httpparser {} // namespace httpparser

--- a/libservice/headers/service/Aggregator.h
+++ b/libservice/headers/service/Aggregator.h
@@ -40,7 +40,6 @@ private:
 	using ServiceKey = std::pair<uint32_t, std::string>;
 
 	ebpfdiscovery::IpAddressChecker& ipChecker;
-	httpparser::XForwardedForValueParser xForwardedForValueParser;
 
 	std::unordered_map<ServiceKey, Service> services;
 	std::mutex servicesMutex;

--- a/libservice/src/Aggregator.cpp
+++ b/libservice/src/Aggregator.cpp
@@ -13,13 +13,7 @@ Aggregator::Aggregator(ebpfdiscovery::IpAddressChecker& ipChecker) : ipChecker(i
 void Aggregator::updateServiceClientsNumber(Service& service, const httpparser::HttpRequest& request, const DiscoverySessionMeta& meta) {
 	std::string clientAddr;
 	if (!request.xForwardedFor.empty()) {
-		xForwardedForValueParser.parse(request.xForwardedFor);
-		if (xForwardedForValueParser.result.addresses.empty()) {
-			LOG_DEBUG("Malformed or empty X-Forwarded-For. (value: `{}`)", request.xForwardedFor);
-			return;
-		}
-		clientAddr = xForwardedForValueParser.result.addresses.front();
-		xForwardedForValueParser.result.clear();
+		clientAddr = request.xForwardedFor.front();
 	} else if (discoverySessionFlagsIsIPv4(meta.flags)) {
 		clientAddr = ebpfdiscovery::ipv4ToString(meta.sourceIPData);
 	} else if (discoverySessionFlagsIsIPv6(meta.flags)) {


### PR DESCRIPTION
PR adds handling of HTTP servers behind reverse proxies.  Currently we only have support for ipv4. Refactor will be handled in another PR.