### PR TITLE
Revert "Segmentation fault when running eBPF Discovery built with new…

### DIFF
--- a/ebpfdiscoverysrv/src/main.cpp
+++ b/ebpfdiscoverysrv/src/main.cpp
@@ -91,7 +91,7 @@ static void setupBpfLogging(
 		perf_buffer* logBuf) {
 	if (logLevel <= logging::LogLevel::Debug) {
 		LOG_DEBUG("Handling of Discovery BPF logging is enabled.");
-		scheduleFunction(ioContext, logBufFetchTimer, logBufFetchInterval, [logBuf]() {
+		scheduleFunction(ioContext, logBufFetchTimer, logBufFetchInterval, [&]() {
 			auto ret{bpflogging::fetchAndLog(logBuf)};
 			if (ret != 0) {
 				LOG_CRITICAL("Failed to fetch and handle Discovery BPF logging: {}.", std::strerror(-ret));


### PR DESCRIPTION
…er GCC versions and trace log level"

This reverts commit c6490500347f91593e63452f0c4df3cce7e25c71.

I have improved our branch protection rules, so no accidental commits by administrators to `main` should happen anymore.