### PR TITLE
Change log directory in component tests

### DIFF
--- a/.github/actions/component-tests/action.yaml
+++ b/.github/actions/component-tests/action.yaml
@@ -24,6 +24,9 @@ runs:
         python -m venv testvenv
         source testvenv/bin/activate
         pip install -r "${{ env.COMPONENT_TESTING_PATH }}/requirements.txt"
-    - name: Component tests
+    - name: Create logs directory
       shell: bash
-      run: sudo testvenv/bin/pytest ${{ env.COMPONENT_TESTING_PATH }} -s -v --discovery_path="${{ env.DISCOVERY_BIN_PATH }}"
+      run: mkdir logs
+    - name: Run tests
+      shell: bash
+      run: sudo testvenv/bin/pytest ${{ env.COMPONENT_TESTING_PATH }} -s -v --discovery_path="${{ env.DISCOVERY_BIN_PATH }}" --log_dir="${{ github.workspace }}/logs"

--- a/.github/actions/load-tests/action.yaml
+++ b/.github/actions/load-tests/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Create logs directory
       shell: bash
       run: mkdir logs
-    - name: Load tests
+    - name: Run tests
       shell: bash
       run: |
         source testvenv/bin/activate


### PR DESCRIPTION
Logs are unintentionally copied with executable for publishing. After reducing log permissions, main branch build fails with the following errors:
```
zip warning: Permission denied
  adding: bin/ (stored 0%)
zip warning: Permission denied
  adding: bin/ebpf_discovery_3918.log
	zip warning: could not open for reading: bin/ebpf_discovery_3918.log
  adding: bin/ebpf_discovery_3950.log
	zip warning: could not open for reading: bin/ebpf_discovery_3950.log
zip warning: Permission denied
  adding: bin/ebpfdiscoverysrv (deflated 66%)
  adding: bin/ebpf_discovery_3935.log
	zip warning: could not open for reading: bin/ebpf_discovery_3935.log
  adding: bin/ebpf_discovery_3903.log
	zip warning: could not open for reading: bin/ebpf_discovery_3903.log
  adding: bin/ebpf_discovery_3895.log
```

This PR changes log location, so that they are not taken into final zip file. 