### PR TITLE
Fix load tests workflow

### DIFF
--- a/.github/actions/run-load-tests/action.yaml
+++ b/.github/actions/run-load-tests/action.yaml
@@ -39,7 +39,7 @@ runs:
       run: |
         sudo chmod -R 777 ${{ github.workspace }}/logs
     - name: "Upload log archive"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: "log-archive"
         path: ${{ github.workspace }}/logs

--- a/.github/actions/run-load-tests/action.yaml
+++ b/.github/actions/run-load-tests/action.yaml
@@ -34,6 +34,10 @@ runs:
         cd ${{ env.LOAD_TESTING_PATH }}
         /bin/bash test_load.sh ${{ env.DISCOVERY_BIN_PATH }} ${{ github.workspace }}/logs 5 5 30m
       continue-on-error: true
+    - name: Set permissions for logs
+      shell: bash
+      run: |
+        sudo chmod -R 777 ${{ github.workspace }}/logs
     - name: "Upload log archive"
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
After reducing default log permissions (https://github.com/dynatrace-oss/eBPF-Discovery/pull/80) workflow with load tests could not upload ebpf-discovery logs. As a result, whole workflow was failing.

Change of permissions in action seems to resolve the issue (verification was done on repo fork). 