### PR TITLE
accept colon and double quote in header values

### DIFF
--- a/libhttpparser/src/HttpRequestParser.cpp
+++ b/libhttpparser/src/HttpRequestParser.cpp
@@ -30,7 +30,7 @@ static constexpr std::string_view HTTP_1_1{"HTTP/1.1"};
 
 static constexpr std::string_view VALID_URL_SPECIAL_CHARS{"-._~:/?#[]@!$&'()*+,;=%"};
 static constexpr std::string_view VALID_HEADER_KEY_SPECIAL_CHARS{"!#$%&'*+-.^_`|~"};
-static constexpr std::string_view VALID_HEADER_VALUE_SPECIAL_CHARS{"`~!@#$%^&*()-_=+[]{}\\|;'<>,.?/ "};
+static constexpr std::string_view VALID_HEADER_VALUE_SPECIAL_CHARS{"`~!@#$%^&*()-_=+[]{}\\|;:'\"<>,.?/ "};
 static constexpr std::string_view VALID_HOST_HEADER_VALUE_SPECIAL_CHARS{"-.:[]"};
 static constexpr std::string_view VALID_CLIENT_IP_HEADER_VALUE_SPECIAL_CHARS{"-.:[], "};
 

--- a/libhttpparser/test/HttpRequestParserTest.cpp
+++ b/libhttpparser/test/HttpRequestParserTest.cpp
@@ -263,6 +263,20 @@ INSTANTIATE_TEST_SUITE_P(
 						"example.com",
 						{"10.0.0.1", "127.0.0.1", "2001:0db8:85a3::8a2e:0370:7335"},
 				},
+				HttpRequestTestData{
+						{"GET /example HTTP/1.1\r\nHost: example.com\r\nReferer: https://example.com/\r\n\r\n"},
+						"GET",
+						"/example",
+						"HTTP/1.1",
+						"example.com",
+						{}},
+				HttpRequestTestData{
+						{"GET /example HTTP/1.1\r\nHost: example.com\r\nSec-CH-UA: \"Chromium\";v=\"124\"\r\n\r\n"},
+						"GET",
+						"/example",
+						"HTTP/1.1",
+						"example.com",
+						{}},
 				HttpRequestTestData{chunkString("GET / HTTP/1.1\r\n", 1), "GET", "/", "HTTP/1.1", "", {}, false, false},
 				HttpRequestTestData{{"GET /"}, "GET", "/", "", "", {}, false, false},
 				HttpRequestTestData{{"", ""}, "", "", "", "", {}, false, false}));


### PR DESCRIPTION
`VALID_HEADER_VALUE_SPECIAL_CHARS` in `libhttpparser/src/HttpRequestParser.cpp:33` lists the punctuation allowed in a header value, and it is missing `:` and `"`:

```cpp
static constexpr std::string_view VALID_HEADER_VALUE_SPECIAL_CHARS{"`~!@#$%^&*()-_=+[]{}\\|;'<>,.?/ "};
```

both are ordinary field-content per RFC 7230, and the neighbouring sets in the same block allow the colon already (`VALID_URL_SPECIAL_CHARS`, `VALID_HOST_HEADER_VALUE_SPECIAL_CHARS`, `VALID_CLIENT_IP_HEADER_VALUE_SPECIAL_CHARS`). the two missing characters are the shifted forms of `;` and `'`, which are both present, so this reads like a slip while typing the set

the effect is not limited to exotic requests. `isValidHeaderValueChar` returning false puts the parser in the invalid state and `Discovery.cpp` drops the whole session, so any request carrying one of these is lost:

- `Referer: https://example.com/` and `Origin: https://example.com` - rejected at the colon
- `Sec-CH-UA: "Chromium";v="124"` - sent by Chrome and Edge on every request in a secure context
- `If-None-Match: "abc123"` - quoted ETag

that is close to all browser traffic to a monitored service

## changes

add `:` and `"` next to the characters they belong with, and add two cases to the valid-request suite covering a `Referer` and a `Sec-CH-UA` header

I built the test suite against the change: 33 tests pass, and against the previous parser exactly those two new cases fail while the other 31 still pass