### PR TITLE
Run sample eBPF program in test-launch mode

### DIFF
--- a/ebpfdiscoverysrv/src/main.cpp
+++ b/ebpfdiscoverysrv/src/main.cpp
@@ -168,7 +168,9 @@ int main(int argc, char** argv) {
 	}
 
 
-	if (enableServiceDetection) {
+	// isLaunchTest probes whether cap_bpf/cap_perfmon actually work on this kernel.
+	// It does so by launching an eBPF program for a brief moment
+	if (enableServiceDetection || isLaunchTest) {
 		try {
 			auto outputServicesToStdoutInterval{std::chrono::seconds(vm[intervalName.data()].as<int>())};
 			const bool enableNetworkCounters{vm[enableNetworkCountersName.data()].as<bool>()};


### PR DESCRIPTION
This has been removed in scope of the recent implementation of short-living processes detection. However, it's required for the installer capability probe.